### PR TITLE
Nicolas's implementation of incredible design pattern (Proxy)

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -27,7 +27,7 @@ android {
         applicationId = "com.example.campus_marketplace"
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
-        minSdk = 23
+        minSdk = flutter.minSdkVersion
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
         versionName = flutter.versionName

--- a/lib/models/models.dart
+++ b/lib/models/models.dart
@@ -331,6 +331,27 @@ class Chat {
   }
 }
 
+class ProductChat {
+  final String chatId;
+  final User otherUser;
+  final Post product;
+  final String? lastMessage;
+  final DateTime? updatedAt;
+  final int unreadCount;
+  final bool isBuyer;
+
+  ProductChat({
+    required this.chatId,
+    required this.otherUser,
+    required this.product,
+    this.lastMessage,
+    this.updatedAt,
+    this.unreadCount = 0,
+    required this.isBuyer,
+  });
+}
+
+
 class Sale {
   final String id; // maps from _id
   final String postId; // 'post/<id>'

--- a/lib/screens/chat_screen.dart
+++ b/lib/screens/chat_screen.dart
@@ -4,7 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:image_picker/image_picker.dart';
 import '../models/models.dart';
-import '../services/chat_service.dart';
+import '../services/chat_api.dart';
 import '../services/storage_service.dart';
 import '../theme/app_colors.dart';
 
@@ -36,6 +36,8 @@ class _ChatScreenState extends State<ChatScreen> {
   bool _isLoading = true;
   bool _isBuyer = true;
   String? _chatId;
+  final ChatApi _chat = ChatApi(); 
+  
 
   @override
   void initState() {
@@ -47,7 +49,7 @@ class _ChatScreenState extends State<ChatScreen> {
     try {
       // Si no tenemos chatId, crearlo o obtenerlo
       if (widget.chatId.isEmpty) {
-        _chatId = await ChatService.getOrCreateProductChat(
+        _chatId = await _chat.getOrCreateProductChat(
           widget.productId,
           widget.sellerId,
         );
@@ -56,7 +58,7 @@ class _ChatScreenState extends State<ChatScreen> {
       }
 
       // Cargar información del chat
-      final chatInfo = await ChatService.getChatInfo(_chatId!);
+      final chatInfo = await _chat.getChatInfo(_chatId!);
       
       if (mounted) {
         setState(() {
@@ -68,7 +70,7 @@ class _ChatScreenState extends State<ChatScreen> {
         });
 
         // Suscribirse a los mensajes
-        _messagesSub = ChatService.streamChatMessages(_chatId!).listen((messages) {
+        _messagesSub = _chat.streamChatMessages(_chatId!).listen((messages) {
           if (mounted) {
             setState(() {
               _messages = messages;
@@ -77,7 +79,7 @@ class _ChatScreenState extends State<ChatScreen> {
         });
 
         // Marcar mensajes como leídos
-        ChatService.markMessagesAsRead(_chatId!);
+        _chat.markMessagesAsRead(_chatId!);
       }
     } catch (e) {
       print('Error initializing chat: $e');
@@ -107,7 +109,7 @@ class _ChatScreenState extends State<ChatScreen> {
     _messageController.clear();
     
     try {
-      await ChatService.sendMessage(
+      await _chat.sendMessage(
         chatId: _chatId!,
         text: text,
       );

--- a/lib/screens/messages_screen.dart
+++ b/lib/screens/messages_screen.dart
@@ -1,8 +1,9 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
-import '../models/models.dart';
-import '../services/chat_service.dart';
+
+import '../models/models.dart' show ProductChat;
+import '../services/chat_api.dart';
 import '../theme/app_colors.dart';
 import '../widgets/loading_shimmer.dart';
 
@@ -14,40 +15,19 @@ class MessagesScreen extends StatefulWidget {
 }
 
 class _MessagesScreenState extends State<MessagesScreen> {
+  final ChatApi _chat = ChatApi();
+
   StreamSubscription<List<ProductChat>>? _subscription;
-  List<ProductChat> _chats = [];
   bool _isLoading = true;
+
+  // Dos listas separadas:
+  List<ProductChat> _buyersChats = [];  // Tú eres seller (otros = buyers)
+  List<ProductChat> _sellersChats = []; // Tú eres buyer  (otros = sellers)
 
   @override
   void initState() {
     super.initState();
     _loadChats();
-  }
-
-  void _loadChats() {
-    setState(() {
-      _isLoading = true;
-    });
-
-    _subscription?.cancel();
-    _subscription = ChatService.streamUserChats().listen(
-      (chats) {
-        if (mounted) {
-          setState(() {
-            _chats = chats;
-            _isLoading = false;
-          });
-        }
-      },
-      onError: (error) {
-        print('Error cargando chats: $error');
-        if (mounted) {
-          setState(() {
-            _isLoading = false;
-          });
-        }
-      },
-    );
   }
 
   @override
@@ -56,12 +36,59 @@ class _MessagesScreenState extends State<MessagesScreen> {
     super.dispose();
   }
 
+  Future<void> _loadChats() async {
+    setState(() => _isLoading = true);
+
+    _subscription?.cancel();
+    _subscription = _chat.streamUserChats().listen(
+      (chats) {
+        // Particionamos por rol del usuario actual en cada chat
+        final buyers = <ProductChat>[];
+        final sellers = <ProductChat>[];
+
+        for (final c in chats) {
+          if (c.isBuyer) {
+            // tú eres buyer => sección "Sellers"
+            sellers.add(c);
+          } else {
+            // tú eres seller => sección "Buyers"
+            buyers.add(c);
+          }
+        }
+
+        // Ordenamos cada sección por updatedAt desc (por si acaso)
+        int _cmp(ProductChat a, ProductChat b) {
+          final aTime = a.updatedAt ?? DateTime.fromMillisecondsSinceEpoch(0);
+          final bTime = b.updatedAt ?? DateTime.fromMillisecondsSinceEpoch(0);
+          return bTime.compareTo(aTime);
+        }
+        buyers.sort(_cmp);
+        sellers.sort(_cmp);
+
+        if (mounted) {
+          setState(() {
+            _buyersChats = buyers;
+            _sellersChats = sellers;
+            _isLoading = false;
+          });
+        }
+      },
+      onError: (e) {
+        if (mounted) {
+          setState(() => _isLoading = false);
+        }
+      },
+    );
+  }
+
   Future<void> _refresh() async {
     _loadChats();
   }
 
   @override
   Widget build(BuildContext context) {
+    final isEmpty = _buyersChats.isEmpty && _sellersChats.isEmpty;
+
     return Scaffold(
       appBar: AppBar(
         title: const Text('Messages'),
@@ -71,42 +98,55 @@ class _MessagesScreenState extends State<MessagesScreen> {
         onRefresh: _refresh,
         child: _isLoading
             ? const LoadingShimmer(width: double.infinity, height: 300)
-            : _chats.isEmpty
-                ? Center(
-                    child: Column(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        Icon(
-                          Icons.chat_bubble_outline,
-                          size: 64,
-                          color: Colors.grey[400],
-                        ),
-                        const SizedBox(height: 16),
-                        Text(
-                          'No conversations yet',
-                          style: TextStyle(
-                            fontSize: 16,
-                            color: Colors.grey[600],
-                          ),
-                        ),
-                        const SizedBox(height: 8),
-                        Text(
-                          'Start a conversation from a product',
-                          style: TextStyle(
-                            fontSize: 14,
-                            color: Colors.grey[500],
-                          ),
-                        ),
+            : isEmpty
+                ? _buildEmptyState(context)
+                : ListView(
+                    children: [
+                      if (_buyersChats.isNotEmpty) ...[
+                        _buildSectionHeader('Buyers'),
+                        ..._buyersChats.map(_buildChatTile),
+                        const SizedBox(height: 12),
                       ],
-                    ),
-                  )
-                : ListView.builder(
-                    itemCount: _chats.length,
-                    itemBuilder: (context, index) {
-                      final chat = _chats[index];
-                      return _buildChatTile(chat);
-                    },
+                      if (_sellersChats.isNotEmpty) ...[
+                        _buildSectionHeader('Sellers'),
+                        ..._sellersChats.map(_buildChatTile),
+                        const SizedBox(height: 12),
+                      ],
+                    ],
                   ),
+      ),
+    );
+  }
+
+  Widget _buildSectionHeader(String title) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+      child: Text(
+        title,
+        style: const TextStyle(
+          fontWeight: FontWeight.w700,
+          fontSize: 16,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildEmptyState(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 32.0),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(Icons.chat_bubble_outline, size: 64, color: Colors.grey[400]),
+            const SizedBox(height: 16),
+            Text('No conversations yet',
+                style: TextStyle(fontSize: 16, color: Colors.grey[600])),
+            const SizedBox(height: 8),
+            Text('Start a conversation from a product',
+                style: TextStyle(fontSize: 14, color: Colors.grey[500])),
+          ],
+        ),
       ),
     );
   }
@@ -122,7 +162,7 @@ class _MessagesScreenState extends State<MessagesScreen> {
             'sellerId': chat.isBuyer ? chat.otherUser.id : '',
           },
         ).then((_) {
-          // Recargar chats al volver
+          // Recargar al volver, por si cambian contadores de unread
           _loadChats();
         });
       },
@@ -130,10 +170,7 @@ class _MessagesScreenState extends State<MessagesScreen> {
         padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
         decoration: BoxDecoration(
           border: Border(
-            bottom: BorderSide(
-              color: Colors.grey[200]!,
-              width: 1,
-            ),
+            bottom: BorderSide(color: Colors.grey[200]!, width: 1),
           ),
         ),
         child: Row(
@@ -151,21 +188,19 @@ class _MessagesScreenState extends State<MessagesScreen> {
                       ? const Icon(Icons.shopping_bag, color: Colors.white)
                       : null,
                 ),
-                // Indicador de mensajes no leídos
+                // Badge de no leídos
                 if (chat.unreadCount > 0)
                   Positioned(
                     right: 0,
                     top: 0,
                     child: Container(
                       padding: const EdgeInsets.all(4),
-                      decoration: BoxDecoration(
+                      decoration: const BoxDecoration(
                         color: AppColors.primaryColor,
                         shape: BoxShape.circle,
                       ),
-                      constraints: const BoxConstraints(
-                        minWidth: 20,
-                        minHeight: 20,
-                      ),
+                      constraints:
+                          const BoxConstraints(minWidth: 20, minHeight: 20),
                       child: Text(
                         chat.unreadCount.toString(),
                         style: const TextStyle(
@@ -180,11 +215,12 @@ class _MessagesScreenState extends State<MessagesScreen> {
               ],
             ),
             const SizedBox(width: 12),
-            // Información del chat
+            // Info del chat
             Expanded(
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
+                  // Nombre del otro usuario + hora
                   Row(
                     mainAxisAlignment: MainAxisAlignment.spaceBetween,
                     children: [
@@ -202,18 +238,16 @@ class _MessagesScreenState extends State<MessagesScreen> {
                       if (chat.updatedAt != null)
                         Text(
                           _formatTime(chat.updatedAt!),
-                          style: TextStyle(
-                            color: Colors.grey[600],
-                            fontSize: 12,
-                          ),
+                          style:
+                              TextStyle(color: Colors.grey[600], fontSize: 12),
                         ),
                     ],
                   ),
                   const SizedBox(height: 2),
-                  // Nombre del producto
+                  // Título del producto
                   Text(
                     chat.product.title,
-                    style: TextStyle(
+                    style: const TextStyle(
                       color: AppColors.primaryColor,
                       fontSize: 14,
                       fontWeight: FontWeight.w500,
@@ -222,7 +256,7 @@ class _MessagesScreenState extends State<MessagesScreen> {
                     overflow: TextOverflow.ellipsis,
                   ),
                   const SizedBox(height: 4),
-                  // Último mensaje
+                  // Último mensaje + precio
                   Row(
                     children: [
                       Expanded(
@@ -240,7 +274,6 @@ class _MessagesScreenState extends State<MessagesScreen> {
                           overflow: TextOverflow.ellipsis,
                         ),
                       ),
-                      // Precio del producto
                       Text(
                         '\$${chat.product.price.toStringAsFixed(0)}',
                         style: TextStyle(
@@ -263,19 +296,12 @@ class _MessagesScreenState extends State<MessagesScreen> {
   String _formatTime(DateTime dateTime) {
     final now = DateTime.now();
     final difference = now.difference(dateTime);
-    
-    if (difference.inDays > 365) {
-      return '${dateTime.year}';
-    } else if (difference.inDays > 30) {
-      return '${dateTime.day}/${dateTime.month}';
-    } else if (difference.inDays > 0) {
-      return '${difference.inDays}d';
-    } else if (difference.inHours > 0) {
-      return '${difference.inHours}h';
-    } else if (difference.inMinutes > 0) {
-      return '${difference.inMinutes}m';
-    } else {
-      return 'Ahora';
-    }
+
+    if (difference.inDays > 365) return '${dateTime.year}';
+    if (difference.inDays > 30) return '${dateTime.day}/${dateTime.month}';
+    if (difference.inDays > 0) return '${difference.inDays}d';
+    if (difference.inHours > 0) return '${difference.inHours}h';
+    if (difference.inMinutes > 0) return '${difference.inMinutes}m';
+    return 'Ahora';
   }
 }

--- a/lib/services/chat_api.dart
+++ b/lib/services/chat_api.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/foundation.dart';
+import '../models/models.dart';
+import 'chat_service.dart' show ChatService;
+
+class ChatApi {
+  final bool enableLogs;
+  ChatApi({this.enableLogs = kDebugMode});
+
+  void _log(String msg) {
+    if (enableLogs) {
+      // ignore: avoid_print
+      print('[ChatApi] $msg');
+    }
+  }
+
+  Future<String> getOrCreateProductChat(String productId, String sellerId) async {
+    final t0 = DateTime.now();
+    _log('getOrCreateProductChat(productId=$productId, sellerId=$sellerId)');
+    try {
+      final r = await ChatService.getOrCreateProductChat(productId, sellerId);
+      _log('getOrCreateProductChat -> $r in ${DateTime.now().difference(t0).inMilliseconds}ms');
+      return r;
+    } catch (e, s) {
+      _log('getOrCreateProductChat ERROR: $e\n$s');
+      rethrow;
+    }
+  }
+
+  Stream<List<ProductChat>> streamUserChats() {
+    _log('streamUserChats()');
+    final t0 = DateTime.now();
+    return ChatService.streamUserChats().map((list) {
+      _log('streamUserChats -> ${list.length} chats in ${DateTime.now().difference(t0).inMilliseconds}ms');
+      return list;
+    });
+  }
+
+  Stream<List<ChatMessage>> streamChatMessages(String chatId) {
+    _log('streamChatMessages(chatId=$chatId)');
+    final t0 = DateTime.now();
+    return ChatService.streamChatMessages(chatId).map((list) {
+      _log('streamChatMessages -> ${list.length} msgs in ${DateTime.now().difference(t0).inMilliseconds}ms');
+      return list;
+    });
+  }
+
+  Future<Map<String, dynamic>> getChatInfo(String chatId) async {
+    final t0 = DateTime.now();
+    _log('getChatInfo(chatId=$chatId)');
+    try {
+      final r = await ChatService.getChatInfo(chatId);
+      _log('getChatInfo -> ok in ${DateTime.now().difference(t0).inMilliseconds}ms');
+      return r;
+    } catch (e, s) {
+      _log('getChatInfo ERROR: $e\n$s');
+      rethrow;
+    }
+  }
+
+  Future<void> sendMessage({
+    required String chatId,
+    String? text,
+    String? imageUrl,
+  }) async {
+    final t0 = DateTime.now();
+    _log('sendMessage(chatId=$chatId, hasText=${(text??"").isNotEmpty}, hasImage=${imageUrl!=null})');
+    try {
+      await ChatService.sendMessage(chatId: chatId, text: text, imageUrl: imageUrl);
+      _log('sendMessage -> ok in ${DateTime.now().difference(t0).inMilliseconds}ms');
+    } catch (e, s) {
+      _log('sendMessage ERROR: $e\n$s');
+      rethrow;
+    }
+  }
+
+  Future<void> markMessagesAsRead(String chatId) async {
+    final t0 = DateTime.now();
+    _log('markMessagesAsRead(chatId=$chatId)');
+    try {
+      await ChatService.markMessagesAsRead(chatId);
+      _log('markMessagesAsRead -> ok in ${DateTime.now().difference(t0).inMilliseconds}ms');
+    } catch (e, s) {
+      _log('markMessagesAsRead ERROR: $e\n$s');
+      rethrow;
+    }
+  }
+
+  Future<String?> pickAndUploadImage() {
+    return ChatService.pickAndUploadImage();
+  }
+}

--- a/lib/services/chat_service.dart
+++ b/lib/services/chat_service.dart
@@ -8,26 +8,6 @@ import 'package:image_picker/image_picker.dart';
 import '../models/models.dart';
 import 'firestore_service.dart';
 
-class ProductChat {
-  final String chatId;
-  final User otherUser;
-  final Post product;
-  final String? lastMessage;
-  final DateTime? updatedAt;
-  final int unreadCount;
-  final bool isBuyer;
-
-  ProductChat({
-    required this.chatId,
-    required this.otherUser,
-    required this.product,
-    this.lastMessage,
-    this.updatedAt,
-    this.unreadCount = 0,
-    required this.isBuyer,
-  });
-}
-
 class ChatService {
   static final FirebaseFirestore _db = FirebaseFirestore.instance;
   static final FirebaseStorage _storage = FirebaseStorage.instance;


### PR DESCRIPTION
Add ChatApi (proxy w/ logging), move ProductChat to models, split inbox into Buyers/Sellers  Introduce lib/services/chat_api.dart as a lightweight Proxy/Facade over ChatService with debug-only logging & timing.  No changes to chat_service.dart logic (only model relocation).  Move ProductChat to lib/models/models.dart and update imports (incl. chat_api.dart).  Refactor ChatScreen to use ChatApi:  Replace static calls with _chat.* (get/create chat, get info, messages stream, mark-as-read, send).  Prevent LateInitializationError via final ChatApi _chat = ChatApi();.  Update MessagesScreen to display two sections:  Buyers (user is the seller → isBuyer == false)  Sellers (user is the buyer → isBuyer == true)  Keep unread badges and sort by updatedAt desc.