### PR TITLE
feat(auth, router, deps): add email verification flow

### DIFF
--- a/lib/models/auth_model.dart
+++ b/lib/models/auth_model.dart
@@ -1,0 +1,11 @@
+class SignUpForm {
+  final String email;
+  final String password;
+  final String name;
+
+  SignUpForm({
+    required this.email,
+    required this.password,
+    required this.name,
+  });
+}

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -14,6 +14,7 @@ import 'screens/profile_screen.dart';
 import 'screens/sales_screen.dart';
 import 'screens/signup_screen.dart';
 import 'widgets/main_scaffold.dart';
+import 'screens/verification_screen.dart';
 
 final _rootNavigatorKey = GlobalKey<NavigatorState>();
 
@@ -28,6 +29,15 @@ final router = GoRouter(
     GoRoute(
       path: '/signup',
       builder: (context, state) => const SignupScreen(),
+    ),
+    GoRoute(
+      path: '/verification',
+      builder: (context, state) {
+        final extra = (state.extra as Map?) ?? {};
+        return VerificationScreen(
+          email: (extra['email'] as String?) ?? '',
+        );
+      },
     ),
     GoRoute(
       path: '/chat',

--- a/lib/screens/signup_screen.dart
+++ b/lib/screens/signup_screen.dart
@@ -1,5 +1,7 @@
+// lib/screens/signup_screen.dart
 import 'package:campus_marketplace/services/auth_service.dart';
 import 'package:campus_marketplace/services/firestore_service.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
@@ -15,29 +17,78 @@ class _SignupScreenState extends State<SignupScreen> {
   String email = '';
   String password = '';
   String confirmPassword = '';
-  AuthService authService = AuthService();
+  final AuthService authService = AuthService();
 
-  _signup() async {
-    var scaffoldMessenger = ScaffoldMessenger.of(context);
-    if (password == confirmPassword) {
-      scaffoldMessenger.showSnackBar(const SnackBar(content: Text('Creating account...')));
-      UserCredential? credential =
-          await authService.signUpWithEmailAndPassword(email, password);
-      if (credential != null) {
-        await FirestoreService.createUser();
-        scaffoldMessenger.hideCurrentSnackBar();
-        if (mounted) {
-          context.go('/home');
-        }
-      } else {
-        scaffoldMessenger.showSnackBar(
-          const SnackBar(content: Text('Sign up failed')),
-        );
-      }
-    } else {
-      scaffoldMessenger.showSnackBar(
+  bool _isUniandes(String e) =>
+      e.trim().toLowerCase().endsWith('@uniandes.edu.co');
+
+  String _mapFirebaseError(FirebaseAuthException e) {
+    final code = e.code.toLowerCase();
+    if (code == 'email-already-in-use') return 'Este correo ya está registrado.';
+    if (code == 'invalid-email') return 'Correo inválido.';
+    if (code == 'weak-password') return 'Contraseña débil.';
+    return e.message ?? 'Error de autenticación';
+  }
+
+  Future<void> _signup() async {
+    final scaffold = ScaffoldMessenger.of(context);
+
+    if (!_isUniandes(email)) {
+      scaffold.showSnackBar(
+        const SnackBar(content: Text('Usa tu correo @uniandes.edu.co')),
+      );
+      return;
+    }
+    if (password != confirmPassword) {
+      scaffold.showSnackBar(
         const SnackBar(content: Text('Passwords do not match')),
       );
+      return;
+    }
+    if (password.length < 6) {
+      scaffold.showSnackBar(
+        const SnackBar(content: Text('La contraseña debe tener al menos 6 caracteres')),
+      );
+      return;
+    }
+
+    try {
+      scaffold.showSnackBar(
+        const SnackBar(content: Text('Creating account...')),
+      );
+
+      // 1) Crear usuario en Firebase Auth
+      final credential = await authService.signUpWithEmailAndPassword(email.trim(), password);
+      final user = credential?.user;
+
+      if (user == null) {
+        scaffold.hideCurrentSnackBar();
+        scaffold.showSnackBar(const SnackBar(content: Text('Sign up failed')));
+        return;
+      }
+
+      // 2) Enviar email de verificación (link nativo)
+      await user.sendEmailVerification();
+
+      // 3) Crear documento de usuario (si no existe) y marcar is_verified=false
+      await FirestoreService.createUser();
+      await FirebaseFirestore.instance
+          .collection('users')
+          .doc(user.uid)
+          .set({'is_verified': false}, SetOptions(merge: true));
+
+      scaffold.hideCurrentSnackBar();
+
+      // 4) Ir a pantalla donde el usuario confirma que ya verificó su email
+      if (mounted) {
+        context.push('/verification', extra: {'email': email.trim()});
+      }
+    } on FirebaseAuthException catch (e) {
+      scaffold.hideCurrentSnackBar();
+      scaffold.showSnackBar(SnackBar(content: Text(_mapFirebaseError(e))));
+    } catch (e) {
+      scaffold.hideCurrentSnackBar();
+      scaffold.showSnackBar(SnackBar(content: Text('Error: $e')));
     }
   }
 
@@ -52,7 +103,6 @@ class _SignupScreenState extends State<SignupScreen> {
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
               const SizedBox(height: 100),
-              // Placeholder for the icon
               const SizedBox(height: 120, width: 120),
               const Text(
                 'MERCANDES',
@@ -74,9 +124,9 @@ class _SignupScreenState extends State<SignupScreen> {
               ),
               const SizedBox(height: 40),
               TextField(
-                onChanged: (value) {
-                  email = value;
-                },
+                onChanged: (value) => email = value,
+                keyboardType: TextInputType.emailAddress,
+                autofillHints: const [AutofillHints.email],
                 decoration: const InputDecoration(
                   labelText: 'Email',
                   border: OutlineInputBorder(),
@@ -84,10 +134,9 @@ class _SignupScreenState extends State<SignupScreen> {
               ),
               const SizedBox(height: 20),
               TextField(
-                onChanged: (value) {
-                  password = value;
-                },
+                onChanged: (value) => password = value,
                 obscureText: true,
+                autofillHints: const [AutofillHints.newPassword],
                 decoration: const InputDecoration(
                   labelText: 'Password',
                   border: OutlineInputBorder(),
@@ -95,10 +144,9 @@ class _SignupScreenState extends State<SignupScreen> {
               ),
               const SizedBox(height: 20),
               TextField(
-                onChanged: (value) {
-                  confirmPassword = value;
-                },
+                onChanged: (value) => confirmPassword = value,
                 obscureText: true,
+                autofillHints: const [AutofillHints.newPassword],
                 decoration: const InputDecoration(
                   labelText: 'Confirm Password',
                   border: OutlineInputBorder(),
@@ -130,11 +178,13 @@ class _SignupScreenState extends State<SignupScreen> {
               const SizedBox(height: 20),
               ElevatedButton.icon(
                 onPressed: () {
+                  // Puedes decidir si omitir verificación por email en Google Sign-In
                   authService.signInWithGoogle();
                 },
                 icon: Image.network(
-                    'http://pngimg.com/uploads/google/google_PNG19635.png',
-                    height: 24.0),
+                  'http://pngimg.com/uploads/google/google_PNG19635.png',
+                  height: 24.0,
+                ),
                 label: const Text('Sign up with Google'),
                 style: ElevatedButton.styleFrom(
                   foregroundColor: Colors.black,
@@ -149,9 +199,7 @@ class _SignupScreenState extends State<SignupScreen> {
                 children: [
                   const Text("Already have an account?"),
                   TextButton(
-                    onPressed: () {
-                      context.go('/login');
-                    },
+                    onPressed: () => context.go('/login'),
                     child: const Text('Sign In'),
                   ),
                 ],

--- a/lib/screens/verification_screen.dart
+++ b/lib/screens/verification_screen.dart
@@ -1,0 +1,94 @@
+// lib/screens/verification_screen.dart
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+class VerificationScreen extends StatefulWidget {
+  final String email;
+  const VerificationScreen({super.key, required this.email});
+
+  @override
+  State<VerificationScreen> createState() => _VerificationScreenState();
+}
+
+class _VerificationScreenState extends State<VerificationScreen> {
+  bool _checking = false;
+  final _auth = FirebaseAuth.instance;
+  final _db = FirebaseFirestore.instance;
+
+  Future<void> _resend() async {
+    final user = _auth.currentUser;
+    if (user == null) return;
+    try {
+      await user.sendEmailVerification();
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Correo reenviado')),
+      );
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Error al reenviar: $e')),
+      );
+    }
+  }
+
+  Future<void> _checkVerified() async {
+    setState(() => _checking = true);
+    try {
+      await _auth.currentUser?.reload();
+      final refreshed = _auth.currentUser;
+      final ok = refreshed?.emailVerified ?? false;
+
+      if (ok) {
+        await _db.collection('users').doc(refreshed!.uid).set(
+          {'is_verified': true},
+          SetOptions(merge: true),
+        );
+        if (!mounted) return;
+        context.go('/home');
+      } else {
+        if (!mounted) return;
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Aún no aparece verificado. Revisa tu correo y vuelve a intentar.')),
+        );
+      }
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Error al verificar: $e')),
+      );
+    } finally {
+      if (mounted) setState(() => _checking = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Verifica tu correo')),
+      body: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          children: [
+            const SizedBox(height: 8),
+            Text('Te enviamos un correo de verificación a:\n${widget.email}',
+                textAlign: TextAlign.center),
+            const SizedBox(height: 24),
+            ElevatedButton(
+              onPressed: _checking ? null : _checkVerified,
+              child: _checking
+                  ? const CircularProgressIndicator()
+                  : const Text('Ya verifiqué mi correo'),
+            ),
+            TextButton(
+              onPressed: _checking ? null : _resend,
+              child: const Text('Reenviar correo'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/services/email_verification.dart
+++ b/lib/services/email_verification.dart
@@ -1,0 +1,86 @@
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import '../models/auth_model.dart';
+
+class SignUpAuthViewModel {
+  final FirebaseAuth _auth;
+  final FirebaseFirestore _db;
+
+  SignUpAuthViewModel({
+    FirebaseAuth? auth,
+    FirebaseFirestore? db,
+  })  : _auth = auth ?? FirebaseAuth.instance,
+        _db = db ?? FirebaseFirestore.instance;
+
+  final String allowedDomain = 'uniandes.edu.co';
+
+  Future<void> register({
+    required SignUpForm form,
+    required void Function() onSuccess,
+    required void Function(String) onError,
+  }) async {
+    final email = form.email.trim();
+    final pass = form.password;
+    final name = form.name.trim();
+
+    final domainOk = email.split('@').length == 2 &&
+        email.split('@').last.toLowerCase() == allowedDomain.toLowerCase();
+
+    if (!domainOk) {
+      onError('Usa tu correo institucional @$allowedDomain');
+      return;
+    }
+    if (pass.length < 6) {
+      onError('La contraseña debe tener al menos 6 caracteres');
+      return;
+    }
+    if (name.isEmpty) {
+      onError('Ingresa tu nombre');
+      return;
+    }
+
+    try {
+      // 1) Crear en Auth
+      final cred = await _auth.createUserWithEmailAndPassword(
+        email: email,
+        password: pass,
+      );
+
+      final user = cred.user;
+      if (user == null) {
+        onError('No se pudo crear el usuario');
+        return;
+      }
+
+      // (opcional) establecer displayName
+      await user.updateDisplayName(name);
+
+      // 2) Enviar verificación por link
+      await user.sendEmailVerification();
+
+      // 3) Guardar perfil en Firestore (sin password)
+      final uid = user.uid;
+      await _db.collection('users').doc(uid).set({
+        'email': email,
+        'name': name,
+        'is_verified': false, // lo pondremos en true cuando confirme
+        'created_at': FieldValue.serverTimestamp(),
+      }, SetOptions(merge: true));
+
+      onSuccess();
+    } on FirebaseAuthException catch (e) {
+      onError(_mapFirebaseError(e));
+    } catch (e) {
+      onError('Error al registrar: ${e.toString()}');
+    }
+  }
+
+  String _mapFirebaseError(FirebaseAuthException e) {
+    final code = e.code.toLowerCase();
+    if (code == 'email-already-in-use') return 'Este correo ya está registrado.';
+    if (code == 'invalid-email') return 'Correo inválido.';
+    if (code == 'weak-password') return 'Contraseña débil.';
+    return e.message ?? 'Error de autenticación';
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -89,6 +89,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.0.1"
+  cloud_functions:
+    dependency: "direct main"
+    description:
+      name: cloud_functions
+      sha256: bf3b5b18b794123d452196e407e5952b4fe002043a373f0acac0f8fc6998567f
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.0.2"
+  cloud_functions_platform_interface:
+    dependency: transitive
+    description:
+      name: cloud_functions_platform_interface
+      sha256: d3a24cb9bf0a0fe8abe71db47d703d368a175d956c40730f7a216211ccbc5d8d
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.8.5"
+  cloud_functions_web:
+    dependency: transitive
+    description:
+      name: cloud_functions_web
+      sha256: dbcde017570afd7186addf8ba7b985a89ddcaf689e76741540d41e7cd0ce5bbe
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.2"
   collection:
     dependency: transitive
     description:
@@ -476,26 +500,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
+      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.9"
+    version: "11.0.2"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.9"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   lints:
     dependency: transitive
     description:
@@ -841,10 +865,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.6"
   typed_data:
     dependency: transitive
     description:
@@ -865,10 +889,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   vm_service:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
   firebase_storage: ^13.0.2
+  cloud_functions: ^6.0.0
 
   # Core packages
   cupertino_icons: ^1.0.6


### PR DESCRIPTION
Update SignupScreen: enforce @uniandes.edu.co domain, create user, send Firebase email verification, create user doc with is_verified=false, and redirect to /verification

Add VerificationScreen to resend verification email, check emailVerified, set users/{uid}.is_verified=true, and navigate to /home

Register /verification as a top-level GoRouter route (keeps bottom nav hidden during verification)